### PR TITLE
fix SlicableVocabulary and it's use in CatalogVocabulary

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 2.1.11 (2013-07-18)
 -------------------
 
+- Add documentation to SlicableVocabulary, fix handling of internal structure
+  [do3cc]
+
 - SlicableVocabulary context is not needed when initialing
   [garbas]
 
@@ -35,7 +38,7 @@ Changelog
 - Make KeywordsVocabulary work with unicode and non-unicode vocabularies.
   [thet]
 
-- Fix exceptions with workflow states/transitions titles when their titles 
+- Fix exceptions with workflow states/transitions titles when their titles
   contained encoded characters [ericof]
 
 - Fix exception with workflow vocabulary when workflow titles contained UTF-8 encoded

--- a/plone/app/vocabularies/__init__.py
+++ b/plone/app/vocabularies/__init__.py
@@ -6,6 +6,10 @@ from plone.app.vocabularies.interfaces import ISlicableVocabulary
 class SlicableVocabulary(object):
     """
     A tokenized voacabulary in which the results can be sliced.
+    This class does not implement a complete vocabulary. Instead you use
+    this class as a mixin to your vocabulary class.
+    This mixin class expects to be used with something resembling
+    a SimpleVocabulary. It accesses internal members like _terms
     """
     implements(ISlicableVocabulary)
 
@@ -16,17 +20,14 @@ class SlicableVocabulary(object):
 
     def __getitem__(self, start, stop=None):
         if isinstance(start, slice):
-            slic = start
-            start = slic.start
-            stop = slic.stop
+            slice_inst = start
+            start = slice_inst.start
+            stop = slice_inst.stop
         elif not stop:
             return self._terms[start]
 
         # sliced up
-        results = []
-        for item in self._terms[start:stop]:
-            results.append(self.getTerm(item))
-        return results
+        return self._terms[start:stop]
 
     def __len__(self):
         return len(self._terms)

--- a/plone/app/vocabularies/users.py
+++ b/plone/app/vocabularies/users.py
@@ -100,8 +100,7 @@ class UsersVocabulary(SlicableVocabulary):
     getTermByToken = getTerm
 
     def __iter__(self):
-        for item in self._terms:
-            yield self.getTerm(item['userid'])
+        return self._terms
 
 
 class UsersFactory(object):
@@ -111,7 +110,7 @@ class UsersFactory(object):
 
     def __call__(self, context, query=''):
         users = getToolByName(context, "acl_users")
-        return UsersVocabulary(users.searchUsers(fullname=query), context)
+        return UsersVocabulary.fromItems(users.searchUsers(fullname=query), context)
 
 
 class UsersSourceQueryView(object):


### PR DESCRIPTION
The vocabularies have been filled wrongly. The items have been stored as _terms. With the correct behavior, I can finally use the Slicable as a Import Mixin for a SimpleVocabulary.
The catalog vocabulary is still working lazily.
