### PR TITLE
Fix issue with missing context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.1.17 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix issue with missing context in plone.app.vocabularies.Users.
+  [pbauer]
 
 
 2.1.16 (2014-09-07)

--- a/plone/app/vocabularies/users.py
+++ b/plone/app/vocabularies/users.py
@@ -1,17 +1,14 @@
-from zope.browser.interfaces import ITerms
-from zope.interface import directlyProvides
-from zope.interface import implements, classProvides
-from zope.schema.interfaces import ISource, IContextSourceBinder
-from zope.schema.interfaces import IVocabularyTokenized
-from zope.schema.interfaces import IVocabularyFactory
-from zope.schema.vocabulary import SimpleTerm
-
-from zope.formlib.interfaces import ISourceQueryView
-
+# -*- coding: utf-8 -*-
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-
 from plone.app.vocabularies import SlicableVocabulary
+from zope.browser.interfaces import ITerms
+from zope.component.hooks import getSite
+from zope.formlib.interfaces import ISourceQueryView
+from zope.interface import implements, classProvides
+from zope.schema.interfaces import ISource, IContextSourceBinder
+from zope.schema.interfaces import IVocabularyFactory
+from zope.schema.vocabulary import SimpleTerm
 
 
 class UsersSource(object):
@@ -109,8 +106,11 @@ class UsersFactory(object):
     implements(IVocabularyFactory)
 
     def __call__(self, context, query=''):
+        if context is None:
+            context = getSite()
         users = getToolByName(context, "acl_users")
-        return UsersVocabulary.fromItems(users.searchUsers(fullname=query), context)
+        return UsersVocabulary.fromItems(
+            users.searchUsers(fullname=query), context)
 
 
 class UsersSourceQueryView(object):


### PR DESCRIPTION
when using plone.app.vocabularies.Users in a single-choice-field:

    responsible = schema.Choice(
        title=_('Person responsinble'),
        vocabulary='plone.app.vocabularies.Users',
        required=True,
    )
    form.widget('responsible', AjaxSelectFieldWidget)

I get a traceback that is fixed by this change. 

    Traceback (innermost last):
      Module ZPublisher.Publish, line 138, in publish
      Module ZPublisher.mapply, line 77, in mapply
      Module Products.PDBDebugMode.runcall, line 70, in pdb_runcall
      Module ZPublisher.Publish, line 48, in call_object
      Module z3c.form.form, line 218, in __call__
      Module kbo.webapp.browser.todo, line 30, in update
      Module plone.dexterity.browser.edit, line 65, in update
      Module plone.z3cform.fieldsets.extensible, line 59, in update
      Module plone.z3cform.patch, line 30, in GroupForm_update
      Module z3c.form.group, line 145, in update
      Module plone.app.z3cform.csrf, line 21, in execute
      Module z3c.form.action, line 98, in execute
      Module z3c.form.button, line 315, in __call__
      Module z3c.form.button, line 170, in __call__
      Module kbo.webapp.browser.todo, line 61, in handleApply
      Module z3c.form.group, line 98, in extractData
      Module z3c.form.form, line 147, in extractData
      Module z3c.form.field, line 303, in extract
      Module z3c.form.converter, line 53, in toFieldValue
      Module zope.schema._field, line 373, in fromUnicode
      Module zope.schema._bootstrapfields, line 182, in validate
      Module zope.schema._field, line 385, in _validate
      Module Zope2.App.schema, line 33, in get
      Module plone.app.vocabularies.users, line 112, in __call__
      Module Products.CMFCore.utils, line 13, in check_getToolByName
      Module Products.CMFCore.utils, line 120, in getToolByName
    AttributeError: acl_users
