### PR TITLE
fix: use unicode for plone.app.vocabularies.SyndicatableFeedItems

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 2.1.19 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Fixed SyndicatableFeedItems to allow unicode characters in objects titles.
+  [Gagaro]
 
 2.1.18 (2015-06-05)
 -------------------

--- a/plone/app/vocabularies/syndication.py
+++ b/plone/app/vocabularies/syndication.py
@@ -56,8 +56,8 @@ class SyndicatableFeedItems(object):
         items = []
         for brain in catalog(**query):
             uid = brain.UID
-            title = '%s(%s)' % (brain.Title,
-                                brain.getPath()[len(site_path) + 1:])
+            title = u'%s(%s)' % (brain.Title.decode('utf8'),
+                                 brain.getPath()[len(site_path) + 1:])
             items.append(SimpleTerm(uid, uid, title))
         return SimpleVocabulary(items)
 


### PR DESCRIPTION
Objects with unicode characters in title will cause the `@@syndication-controlpanel` view to break.