### PR TITLE
Add Creators vocabulary

### DIFF
--- a/plone/app/vocabularies/catalog.py
+++ b/plone/app/vocabularies/catalog.py
@@ -464,6 +464,15 @@ class KeywordsVocabulary(object):
 KeywordsVocabularyFactory = KeywordsVocabulary()
 
 
+class CreatorsVocabulary(KeywordsVocabulary):
+    # Creator is not a KeywordIndex, but a FieldIndex.  Seems to work
+    # fine though.
+    keyword_index = 'Creator'
+
+
+CreatorsVocabularyFactory = CreatorsVocabulary()
+
+
 class CatalogVocabulary(SlicableVocabulary):
     # We want to get rid of this and use CatalogSource instead,
     # but we can't in Plone versions that support

--- a/plone/app/vocabularies/configure.zcml
+++ b/plone/app/vocabularies/configure.zcml
@@ -78,6 +78,11 @@
     />
 
   <utility
+    component=".catalog.CreatorsVocabularyFactory"
+    name="plone.app.vocabularies.Creators"
+    />
+
+  <utility
     component=".syndication.SyndicationFeedTypesVocabularyFactory"
     name="plone.app.vocabularies.SyndicationFeedTypes"
     />


### PR DESCRIPTION
Nice to use this for the Creator query in a Collection, instead of the Users vocabulary.

Would be nice to have tests for this, which I tried. Current similar tests mock all kinds of things, which failed for me. Other tests that actually have a portal don't have any content and only have Discussion Item and TempFolder as content types, and I couldn't even create a Discussion Item. Maybe some other base class or test fixture and all would be fine, but it has to work on Plone 4.3 and 5.0, so I gave up.

Showing fullnames would be nice.
