### PR TITLE
Optional keywords of current navigationroot only.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,13 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Optional allow to filter keyword vocabulary to a current *section* based on the current context.
+  The class was build for easy subclassing - and still is.
+  It allows to override the section fetching logic in a subclass.
+  The default logic is first to look in the controlpanel if there is a ``IEditingSchema.subjects_of_navigation_root`` boolean.
+  If its ``True`` the ``getNavigationRootObject`` is used as the section and only keywords used in this section are part of the vocabulary.
+  Otherwise all keywords in the index are displayed.
+  [jensens]
 
 Bug fixes:
 

--- a/README.rst
+++ b/README.rst
@@ -98,8 +98,14 @@ Catalog
 -------
 
 ``plone.app.vocabularies.Keywords``
-    All Subjects aka Tags aka Keywords used by the portals content
+    It either displays all Subjects aka Tags aka Keywords used by the portals content.
+    Or if there is a ``IEditingSchema.subjects_of_navigation_root`` boolean set to True in the registry,
+    the ``getNavigationRootObject`` is used as the section and only keywords used in this section are part of the vocabulary.
 
+    Developers can subclass ``plone.app.vocabularies.catalog.KeywordVocabulary``, it is build to be developer friendly.
+    ``keyword_index`` property may be redefined to use a different index than 'Subject' for the Keywords.
+    ``path_index`` property may be redefined to use a different index than ``path`` for the sections path
+    ``section`` method may be redefined to located the section keywords should be restricted to.
 
 ``plone.app.vocabularies.Catalog``
     Generic queryable catalog

--- a/plone/app/vocabularies/editors.py
+++ b/plone/app/vocabularies/editors.py
@@ -19,7 +19,11 @@ class AvailableEditorsVocabulary(object):
         items = []
 
         registry = getUtility(IRegistry)
-        settings = registry.forInterface(IEditingSchema, prefix="plone")
+        settings = registry.forInterface(
+            IEditingSchema,
+            prefix="plone",
+            check=False
+        )
 
         if settings:
             editors = settings.available_editors

--- a/plone/app/vocabularies/tests/base.py
+++ b/plone/app/vocabularies/tests/base.py
@@ -2,7 +2,7 @@
 from Products.ZCTextIndex.ParseTree import ParseError
 from plone.app.layout.navigation.interfaces import INavigationRoot
 from OFS.interfaces import IItem
-from zope.interface import implements
+from zope.interface import implementer
 from zope.site.hooks import setSite
 
 
@@ -19,22 +19,14 @@ class DummyContext(object):
         self.__parent__ = None
 
     def getSiteManager(self):
-        return self
-
-    def queryUtility(self, iface, name='', default=None):
-        """Query for a utility.
-
-        Note that earlier zope.component versions had 'provided'
-        instead of 'iface', but that should not matter.
-        """
-        return default
+        from zope.component import getSiteManager
+        return getSiteManager()
 
     def getPhysicalPath(self):
         return ['', self.__name__]
 
     def absolute_url(self, relative=False):
         return '/'.join(self.getPhysicalPath())
-
 
 
 class DummyUrlTool(object):
@@ -107,8 +99,8 @@ class Brain(object):
         return self.rid
 
 
+@implementer(IItem)
 class DummyCatalog(dict):
-    implements(IItem)
 
     def __init__(self, values):
         self.indexes = {}
@@ -145,8 +137,30 @@ class DummyContent(object):
         return self.subjects
 
 
+class DummyContentWithParent(object):
+    __parent__ = None
+
+    def __init__(self, cid, title=None, subjects=[], parent=None):
+        self.__name__ = cid
+        self.__parent__ = parent
+        self.title = title or cid
+        self.subjects = subjects
+
+    def Title(self):
+        return self.title
+
+    def Subject(self):
+        return self.subjects
+
+    def getPhysicalPath(self):
+        return self.__parent__.getPhysicalPath() + [self.__name__]
+
+    def absolute_url(self, relative=False):
+        return '/'.join(self.getPhysicalPath())
+
+
+@implementer(INavigationRoot)
 class DummyNavRoot(object):
-    implements(INavigationRoot)
     __parent__ = None
 
     def __init__(self, _id, title=None, parent=None):

--- a/plone/app/vocabularies/tests/test_imagesvocabularies.py
+++ b/plone/app/vocabularies/tests/test_imagesvocabularies.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from plone.app.vocabularies.testing import PAVocabularies_INTEGRATION_TESTING
-from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
 from zope.schema.interfaces import IVocabularyFactory
 import unittest

--- a/plone/app/vocabularies/tests/test_subjects_under_context.py
+++ b/plone/app/vocabularies/tests/test_subjects_under_context.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+from plone.app.vocabularies.testing import PAVocabularies_INTEGRATION_TESTING
+from zope.interface import alsoProvides
+from plone.app.layout.navigation.interfaces import INavigationRoot
+
+import mock
+import unittest2 as unittest
+
+
+class TestKeywordsUnderContext(unittest.TestCase):
+
+    layer = PAVocabularies_INTEGRATION_TESTING
+
+    def setUp(self):
+        """Custom setup for tests."""
+        self.portal = self.layer['portal']
+
+        from plone.app.vocabularies.tests import base
+        context = base.create_context()
+        rids = ('1', '2',)
+        tool = base.DummyCatalog(rids)
+        context.portal_catalog = tool
+        context.portal_url = base.DummyUrlTool(context)
+
+        from Products.PluginIndexes.KeywordIndex.KeywordIndex import KeywordIndex  # noqa
+        kwindex = KeywordIndex('Subject')
+        tool.indexes['Subject'] = kwindex
+        from Products.ExtendedPathIndex.ExtendedPathIndex import ExtendedPathIndex  # noqa
+        pathindex = ExtendedPathIndex('path')
+        tool.indexes['path'] = pathindex
+
+        self.subjects_1 = ['Berlin', 'Wien', 'Paris', 'Barcelona']
+        self.subjects_2 = ['Montreal', 'Washington', 'Brasilia']
+
+        self.navroot1 = base.DummyContentWithParent('nr1', parent=context)
+        alsoProvides(self.navroot1, INavigationRoot)
+        self.navroot2 = base.DummyContentWithParent('nr2', parent=context)
+        alsoProvides(self.navroot2, INavigationRoot)
+
+        self.doc1 = base.DummyContentWithParent(
+            'doc1',
+            subjects=self.subjects_1,
+            parent=self.navroot1
+        )
+        kwindex._index_object(1, self.doc1, attr='Subject')
+        pathindex.index_object(1, self.doc1)
+
+        self.doc2 = base.DummyContentWithParent(
+            'doc2',
+            subjects=self.subjects_2,
+            parent=self.navroot2
+        )
+        kwindex._index_object(2, self.doc2, attr='Subject')
+        pathindex.index_object(2, self.doc2)
+
+        from plone.app.vocabularies.catalog import KeywordsVocabulary
+        self.vocab = KeywordsVocabulary()
+
+        # mock our registry
+        from plone.registry import Registry
+        from plone.registry.interfaces import IRegistry
+        from zope.component import getSiteManager
+        sm = getSiteManager()
+        registry = Registry()
+        sm.registerUtility(registry, IRegistry)
+        registry_patcher = mock.patch(
+            'plone.registry.registry.Registry.get'
+        )
+        self.addCleanup(registry_patcher.stop)
+        self.registry_mock = registry_patcher.start()
+
+    def test_all_kw(self):
+        self.registry_mock.return_value = False
+        self.assertEqual(len(self.vocab(self.doc1)), 7)
+        self.assertEqual(len(self.vocab(self.doc2)), 7)
+
+    def test_all_kw_none_setting(self):
+        self.registry_mock.return_value = None
+        self.assertEqual(len(self.vocab(self.doc1)), 7)
+        self.assertEqual(len(self.vocab(self.doc2)), 7)
+
+    def test_keywords_of_navroot(self):
+        self.registry_mock.return_value = True
+        self.assertEqual(len(self.vocab(self.doc1)), 4)
+        self.assertEqual(len(self.vocab(self.doc2)), 3)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
     ],
-    keywords='Plone Zope formlib vocabularies',
+    keywords='Plone Zope vocabularies',
     author='Plone Foundation',
     author_email='plone-developers@lists.sourceforge.net',
     url='https://github.com/plone/plone.app.vocabularies',
@@ -48,6 +48,7 @@ setup(
     ],
     extras_require=dict(
         test=[
+            'mock',
             'plone.app.testing',
             'zope.configuration',
             'zope.testing',


### PR DESCRIPTION
Optional allow to filter keyword vocabulary to a current *section* based on the current context. 

The class was build for easy subclassing - and still is. It allows to override the section fetching logic in a subclass. The default logic is first to look in the controlpanel if there is a ``IEditingSchema.subjects_of_navigation_root`` boolean. If its ``True`` the ``getNavigationRootObject`` is used as the section and only keywords used in this section are part of the vocabulary. Otherwise all keywords in the index are displayed.