### PR TITLE
avoid dependency on plone.app.imaging

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,8 @@ New features:
 ------------------
 
 Bug fixes:
+- Import getAllowedSizes from CMFPlone to avoid dependency on plone.app.imaging.
+  [davisagli]
 
 - Fix bug where queries would not be parsed correctly for date queries on the catalog
   vocabulary

--- a/plone/app/vocabularies/images.py
+++ b/plone/app/vocabularies/images.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from plone.app.imaging.utils import getAllowedSizes
+from Products.CMFPlone.utils import getAllowedSizes
 from zope.i18nmessageid import MessageFactory
 from zope.interface import provider
 from zope.schema.interfaces import IVocabularyFactory
@@ -11,7 +11,7 @@ PMF = MessageFactory('plone')
 
 @provider(IVocabularyFactory)
 def ScalesVocabulary(context):
-    """Obtains available scales from plone.app.imaging
+    """Obtains available scales from registry
     """
     terms = []
     for scale, (width, height) in getAllowedSizes().iteritems():

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
     install_requires=[
         'Acquisition',
         'plone.app.querystring',
-        'plone.app.imaging',
         'Products.CMFCore',
         'pytz',
         'setuptools',


### PR DESCRIPTION
We don't want to depend on plone.app.imaging, because it's focused on scales for Archetypes image fields and requires Products.Archetypes. This changes an import to get getAllowedSizes from Products.CMFPlone instead of plone.app.imaging.