### PR TITLE
Permissive vocabulary fixes two GenericSetup import issues for add-ons

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,11 @@ Bug fixes:
   month vocabularies to avoid breaking GenericSetup import.
   [seanupton]
 
+- #1268: use permissive vocabulary type for ReallyUserFriendlyTypes,
+  to avoid insertion of new types in plone.displayed_types (registry)
+  from breaking GenericSetup profiles in add-ons.
+  [seanupton]
+
 
 4.0.1 (2017-01-12)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,13 +14,15 @@ New features:
 
 Bug fixes:
 
-- #1794: use permissive vocabulary type for numeric-indexed weekday and
-  month vocabularies to avoid breaking GenericSetup import.
+- plone/Products.CMFPlone#1794: use permissive vocabulary type
+  for numeric-indexed weekday and month vocabularies
+  to avoid breaking GenericSetup import.
   [seanupton]
 
-- #1268: use permissive vocabulary type for ReallyUserFriendlyTypes,
-  to avoid insertion of new types in plone.displayed_types (registry)
-  from breaking GenericSetup profiles in add-ons.
+- plone/Products.CMFPlone#1268: use permissive vocabulary type
+  for ReallyUserFriendlyTypes, to avoid insertion of new types 
+  in plone.displayed_types (registry) from breaking GenericSetup
+  profiles in add-ons.
   [seanupton]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- #1794: use permissive vocabulary type for numeric-indexed weekday and
+  month vocabularies to avoid breaking GenericSetup import.
+  [seanupton]
 
 
 4.0.1 (2017-01-12)

--- a/plone/app/vocabularies/__init__.py
+++ b/plone/app/vocabularies/__init__.py
@@ -3,7 +3,15 @@ from plone.app.vocabularies.interfaces import ISlicableVocabulary
 from plone.app.vocabularies.interfaces import IPermissiveVocabulary
 from zope.interface import directlyProvides
 from zope.interface import implementer
-from zope.schema.vocabulary import SimpleVocabulary, SimpleTerm
+from zope.schema.vocabulary import SimpleTerm
+from zope.schema.vocabulary import SimpleVocabulary
+
+import urllib
+
+
+_token_parse_py3 = getattr(urllib, 'parse', None)
+_token_parse_py27 = lambda token: urllib.unquote_plus(token).decode('utf8')
+parse = _token_parse_py3.unquote if _token_parse_py3 else _token_parse_py27
 
 
 @implementer(ISlicableVocabulary)
@@ -56,6 +64,6 @@ class PermissiveVocabulary(SimpleVocabulary):
             v = super(PermissiveVocabulary, self).getTermByToken(token)
         except LookupError:
             # fallback using dummy term, assumes token==value
-            return SimpleTerm(token)
+            return SimpleTerm(token, title=parse(token))
         return v
 

--- a/plone/app/vocabularies/datetimerelated.py
+++ b/plone/app/vocabularies/datetimerelated.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from plone.app.vocabularies import PermissiveVocabulary
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
 from zope.i18nmessageid import MessageFactory
@@ -66,66 +67,126 @@ WEEKDAY_PREFIXES = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']
 def WeekdaysFactory(context):
     """Vocabulary for Weekdays - full name
 
-      >>> from zope.component import queryUtility
-      >>> from plone.app.vocabularies.tests.base import create_context
+    Usage:
+    ------
 
-      >>> name = 'plone.app.vocabularies.Weekdays'
-      >>> util = queryUtility(IVocabularyFactory, name)
-      >>> context = create_context()
+    Get vocabulary for all seven days:
 
-      >>> len(util(context))
-      7
+        >>> from zope.component import queryUtility
+        >>> from plone.app.vocabularies.tests.base import create_context
 
-      >>> util(context).by_token['0'].title
-      u'weekday_mon'
+        >>> name = 'plone.app.vocabularies.Weekdays'
+        >>> util = queryUtility(IVocabularyFactory, name)
+        >>> context = create_context()
+
+        >>> len(util(context))
+        7
+
+    Containment is unenforced, as numeric tokens are used, a permissive
+    vocabulary type is in use (to make GenericSetup profile
+    import happy):
+
+        >>> assert '1' in util(context)
+        >>> assert 1 in util(context)
+
+    Term values are all integers:
+
+        >>> assert all(map(lambda t: type(t.value) is int, util(context)))
+
+    Term titles are i18n labels:
+
+        >>> util(context).by_token['0'].title
+        u'weekday_mon'
     """
     items = []
     for idx in range(len(WEEKDAY_PREFIXES)):
         msgstr = PLMF('weekday_{0}'.format(WEEKDAY_PREFIXES[idx]))
         items.append(SimpleTerm(idx, str(idx), msgstr))
-    return SimpleVocabulary(items)
+    return PermissiveVocabulary(items)
 
 
 @provider(IVocabularyFactory)
 def WeekdaysAbbrFactory(context):
     """Vocabulary for Weekdays - abbreviated (3 char)
 
-      >>> from zope.component import queryUtility
-      >>> from plone.app.vocabularies.tests.base import create_context
+    Usage:
+    ------
 
-      >>> name = 'plone.app.vocabularies.WeekdaysAbbr'
-      >>> util = queryUtility(IVocabularyFactory, name)
-      >>> context = create_context()
+    Get vocabulary for all seven days:
 
-      >>> len(util(context))
-      7
+        >>> from zope.component import queryUtility
+        >>> from plone.app.vocabularies.tests.base import create_context
+
+        >>> name = 'plone.app.vocabularies.WeekdaysAbbr'
+        >>> util = queryUtility(IVocabularyFactory, name)
+        >>> context = create_context()
+
+        >>> len(util(context))
+        7
+
+    Containment is unenforced, as numeric tokens are used, a permissive
+    vocabulary type is in use (to make GenericSetup profile
+    import happy):
+
+        >>> assert '1' in util(context)
+        >>> assert 1 in util(context)
+
+    Term values are all integers:
+
+        >>> assert all(map(lambda t: type(t.value) is int, util(context)))
+
+    Term titles are i18n labels:
+
+        >>> util(context).by_token['0'].title
+        u'weekday_mon_abbr'
     """
     items = []
     for idx in range(len(WEEKDAY_PREFIXES)):
         msgstr = PLMF('weekday_{0}_abbr'.format(WEEKDAY_PREFIXES[idx]))
         items.append(SimpleTerm(idx, str(idx), msgstr))
-    return SimpleVocabulary(items)
+    return PermissiveVocabulary(items)
 
 
 @provider(IVocabularyFactory)
 def WeekdaysShortFactory(context):
     """Vocabulary for Weekdays - Short (2 char)
 
-      >>> from zope.component import queryUtility
-      >>> from plone.app.vocabularies.tests.base import create_context
+    Usage:
+    ------
 
-      >>> name = 'plone.app.vocabularies.WeekdaysShort'
-      >>> util = queryUtility(IVocabularyFactory, name)
-      >>> context = create_context()
+    Get vocabulary for all seven days:
 
-      >>> len(util(context))
-      7
+        >>> from zope.component import queryUtility
+        >>> from plone.app.vocabularies.tests.base import create_context
+
+        >>> name = 'plone.app.vocabularies.WeekdaysShort'
+        >>> util = queryUtility(IVocabularyFactory, name)
+        >>> context = create_context()
+
+        >>> len(util(context))
+        7
+
+    Containment is unenforced, as numeric tokens are used, a permissive
+    vocabulary type is in use (to make GenericSetup profile
+    import happy):
+
+        >>> assert '1' in util(context)
+        >>> assert 1 in util(context)
+
+    Term values are all integers:
+
+        >>> assert all(map(lambda t: type(t.value) is int, util(context)))
+
+    Term titles are i18n labels:
+
+        >>> util(context).by_token['0'].title
+        u'weekday_mon_short'
     """
     items = []
     for idx in range(len(WEEKDAY_PREFIXES)):
         msgstr = PLMF('weekday_{0}_short'.format(WEEKDAY_PREFIXES[idx]))
         items.append(SimpleTerm(idx, str(idx), msgstr))
-    return SimpleVocabulary(items)
+    return PermissiveVocabulary(items)
 
 
 MONTH_PREFIXES = ['jan', 'feb', 'mar', 'apr', 'may', 'jun',
@@ -136,39 +197,65 @@ MONTH_PREFIXES = ['jan', 'feb', 'mar', 'apr', 'may', 'jun',
 def MonthFactory(context):
     """Vocabulary for Month. Full name
 
-      >>> from zope.component import queryUtility
-      >>> from plone.app.vocabularies.tests.base import create_context
+    Usage:
 
-      >>> name = 'plone.app.vocabularies.Month'
-      >>> util = queryUtility(IVocabularyFactory, name)
-      >>> context = create_context()
+        >>> from zope.component import queryUtility
+        >>> from plone.app.vocabularies.tests.base import create_context
 
-      >>> len(util(context))
-      12
+        >>> name = 'plone.app.vocabularies.Month'
+        >>> util = queryUtility(IVocabularyFactory, name)
+        >>> context = create_context()
+
+        >>> len(util(context))
+        12
+
+    Containment is unenforced, as numeric tokens are used, a permissive
+    vocabulary type is in use (to make GenericSetup profile
+    import happy):
+
+        >>> assert '1' in util(context)
+        >>> assert 1 in util(context)
+
+    Term values are all integers:
+
+        >>> assert all(map(lambda t: type(t.value) is int, util(context)))
     """
     items = []
     for idx in range(len(MONTH_PREFIXES)):
         msgstr = PLMF('month_{0}'.format(MONTH_PREFIXES[idx]))
         items.append(SimpleTerm(idx, str(idx), msgstr))
-    return SimpleVocabulary(items)
+    return PermissiveVocabulary(items)
 
 
 @provider(IVocabularyFactory)
 def MonthAbbrFactory(context):
     """Vocabulary for Month. Abbreviated Name (3 char)
 
-      >>> from zope.component import queryUtility
-      >>> from plone.app.vocabularies.tests.base import create_context
+    Usage:
 
-      >>> name = 'plone.app.vocabularies.MonthAbbr'
-      >>> util = queryUtility(IVocabularyFactory, name)
-      >>> context = create_context()
+        >>> from zope.component import queryUtility
+        >>> from plone.app.vocabularies.tests.base import create_context
 
-      >>> len(util(context))
-      12
+        >>> name = 'plone.app.vocabularies.MonthAbbr'
+        >>> util = queryUtility(IVocabularyFactory, name)
+        >>> context = create_context()
+
+        >>> len(util(context))
+        12
+
+    Containment is unenforced, as numeric tokens are used, a permissive
+    vocabulary type is in use (to make GenericSetup profile
+    import happy):
+
+        >>> assert '1' in util(context)
+        >>> assert 1 in util(context)
+
+    Term values are all integers:
+
+        >>> assert all(map(lambda t: type(t.value) is int, util(context)))
     """
     items = []
     for idx in range(len(MONTH_PREFIXES)):
         msgstr = PLMF('month_{0}_abbr'.format(MONTH_PREFIXES[idx]))
         items.append(SimpleTerm(idx, str(idx), msgstr))
-    return SimpleVocabulary(items)
+    return PermissiveVocabulary(items)

--- a/plone/app/vocabularies/interfaces.py
+++ b/plone/app/vocabularies/interfaces.py
@@ -43,3 +43,16 @@ class ISlicableVocabulary(IVocabularyTokenized):
 
     def __getitem__(start, stop):
         """ return a slice of the results"""
+
+
+class IPermissiveVocabulary(IVocabularyTokenized):
+    """Vocabulary with permissive validation of containment"""
+
+    def __contains__(self, value):
+        """
+        Always returns true, for any value; useful for cases where
+        validation of containment creates practical problems (e.g.
+        vocabulary about to be mutated with insertion of a value not
+        yet within).
+        """
+

--- a/plone/app/vocabularies/types.py
+++ b/plone/app/vocabularies/types.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from Acquisition import aq_get
+from plone.app.vocabularies import PermissiveVocabulary
 from Products.CMFCore.utils import getToolByName
 from zope.i18n import translate
 from zope.interface import implementer
@@ -263,29 +264,36 @@ BAD_TYPES = [
 class ReallyUserFriendlyTypesVocabulary(object):
     """Vocabulary factory for really user friendly portal types.
 
-      >>> from zope.component import queryUtility
-      >>> from plone.app.vocabularies.tests.base import create_context
-      >>> from plone.app.vocabularies.tests.base import DummyType
-      >>> from plone.app.vocabularies.tests.base import DummyTypeTool
+    Usage:
 
-      >>> name = 'plone.app.vocabularies.ReallyUserFriendlyTypes'
-      >>> util = queryUtility(IVocabularyFactory, name)
-      >>> context = create_context()
+        >>> from zope.component import queryUtility
+        >>> from plone.app.vocabularies.tests.base import create_context
+        >>> from plone.app.vocabularies.tests.base import DummyType
+        >>> from plone.app.vocabularies.tests.base import DummyTypeTool
 
-      >>> tool = DummyTypeTool()
-      >>> tool['ATBooleanCriterion'] = DummyType('Boolean Criterion')
-      >>> context.portal_types = tool
+        >>> name = 'plone.app.vocabularies.ReallyUserFriendlyTypes'
+        >>> util = queryUtility(IVocabularyFactory, name)
+        >>> context = create_context()
 
-      >>> types = util(context)
-      >>> types
-      <zope.schema.vocabulary.SimpleVocabulary object at ...>
+        >>> tool = DummyTypeTool()
+        >>> tool['ATBooleanCriterion'] = DummyType('Boolean Criterion')
+        >>> context.portal_types = tool
 
-      >>> len(types.by_token)
-      2
+        >>> types = util(context)
+        >>> types
+        <plone.app.vocabularies.PermissiveVocabulary object at ...>
 
-      >>> doc = types.by_token['Document']
-      >>> doc.title, doc.token, doc.value
-      (u'Page', 'Document', 'Document')
+        >>> len(types.by_token)
+        2
+
+    Containment is unenforced, to make GenericSetup import validation
+    handle validation triggered by Choice.fromUnicode() on insertion:
+
+        >>> assert 'arbitrary_value' in util(context)
+
+        >>> doc = types.by_token['Document']
+        >>> doc.title, doc.token, doc.value
+        (u'Page', 'Document', 'Document')
     """
 
     def __call__(self, context):
@@ -302,6 +310,6 @@ class ReallyUserFriendlyTypesVocabulary(object):
         ]
         items.sort()
         items = [SimpleTerm(i[1], i[1], i[0]) for i in items]
-        return SimpleVocabulary(items)
+        return PermissiveVocabulary(items)
 
 ReallyUserFriendlyTypesVocabularyFactory = ReallyUserFriendlyTypesVocabulary()


### PR DESCRIPTION
See referenced issues https://github.com/plone/Products.CMFPlone/issues/1268 and https://github.com/plone/Products.CMFPlone/issues/1794

The commits in this PR use a subclass of SimpleVocabulary that has permissive containment checks to solve the two scenarios that throw GS import in those two bugs:

1. Numeric indexes as vocabulary keys do not play nice with Choice.fromUnicode()

2. Importing registry entries to whitelist a type name may happen before type is imported, and there's no easy way around this besides making the vocabulary more permissive on validation.