### PR TITLE
Refactor users and groups vocabulary/ add principals vocabulary

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,14 @@ Users, Groups, Security
     Combined groups and users of the portal (searchable).
     Values are prefixed by ``group:...`` or ``user:...``.
 
+The factory-class of the above three vocabularies is made for subclassing to filter the results in the subclass.
+The post-filtering approach works by overriding the ``def use_principal_triple(self, principal_triple):`` method of the ``plone.app.vocabularies.principals.BaseFactory`` subclass.
+``use_principal_triple`` argument ``principal_triple`` is a triple ``(token, value, title)``.
+``use_principal_triple`` is expected to return ``True`` when the triple has be added to the vocabulary or ``False`` if it has to be skipped.
+Be aware there might be many values, like several 1000, in the vocabulary and the filtering has to be perform.
+The subclass needs to have a ``source`` attribute with value one out of ``user``, ``group`` or ``principal``.
+Don't forget to register the new vocabulary in ZCML!
+
 ``plone.app.vocabularies.Roles``
     all possible roles in the portal
 

--- a/README.rst
+++ b/README.rst
@@ -35,9 +35,9 @@ Users, Groups, Security
 
 The factory-class of the above three vocabularies is made for subclassing to filter the results in the subclass.
 The post-filtering approach works by overriding the ``def use_principal_triple(self, principal_triple):`` method of the ``plone.app.vocabularies.principals.BaseFactory`` subclass.
-``use_principal_triple`` argument ``principal_triple`` is a triple ``(token, value, title)``.
+``use_principal_triple`` argument ``principal_triple`` is a triple ``(value, token, title)``.
 ``use_principal_triple`` is expected to return ``True`` when the triple has be added to the vocabulary or ``False`` if it has to be skipped.
-Be aware there might be many values, like several 1000, in the vocabulary and the filtering has to be perform.
+Be aware there might be many values, like several thousands, in the vocabulary and the filtering has to be perform.
 The subclass needs to have a ``source`` attribute with value one out of ``user``, ``group`` or ``principal``.
 Don't forget to register the new vocabulary in ZCML!
 

--- a/README.rst
+++ b/README.rst
@@ -24,13 +24,20 @@ Users, Groups, Security
 -----------------------
 
 ``plone.app.vocabularies.Users``
-    user of the portal (searchable)
+    Users of the portal (searchable).
 
 ``plone.app.vocabularies.Groups``
-    groups of the portal (searchable)
+    Groups of the portal (searchable).
+
+``plone.app.vocabularies.Principals``
+    Combined groups and users of the portal (searchable).
+    Values are prefixed by ``group:...`` or ``user:...``.
 
 ``plone.app.vocabularies.Roles``
     all possible roles in the portal
+
+``plone.app.vocabularies.Permissions``
+    all possible permissions in the portal
 
 Text Input Field
 ----------------

--- a/news/56.feature
+++ b/news/56.feature
@@ -1,0 +1,13 @@
+Overhaul of the groups-vocabulary ``plone.app.vocabularies.Groups``,
+a refined version of the users-vocabulary ``plone.app.vocabularies.Users``,
+a new principals vocabulary combining users and groups ``plone.app.vocabularies.Principals``.
+Ability to apply a filter to the vocabularies in subclasses.
+Moved all to ``principals.py``, bbb import are in place (``user.py``, ``security,py``).
+Deprecated the ``UserSource`` and ``GroupsSource`` implementations.
+Documented new vocabulary in ``README.rst``.
+Move doctests to unittests and added more tests.
+Benefits:
+200x faster validation of groups;
+less and cleaner code;
+unified code for all three vocabularies.
+[jensens]

--- a/plone/app/vocabularies/__init__.py
+++ b/plone/app/vocabularies/__init__.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
-from plone.app.vocabularies.interfaces import ISlicableVocabulary
 from plone.app.vocabularies.interfaces import IPermissiveVocabulary
+from plone.app.vocabularies.interfaces import ISlicableVocabulary
 from six.moves import urllib
 from zope.interface import directlyProvides
 from zope.interface import implementer
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
+
 
 _token_parse_py3 = getattr(urllib, 'parse', None)
 _token_parse_py27 = lambda token: urllib.unquote_plus(token).decode('utf8')
@@ -64,4 +65,3 @@ class PermissiveVocabulary(SimpleVocabulary):
             # fallback using dummy term, assumes token==value
             return SimpleTerm(token, title=parse(token))
         return v
-

--- a/plone/app/vocabularies/configure.zcml
+++ b/plone/app/vocabularies/configure.zcml
@@ -18,11 +18,6 @@
     />
 
   <utility
-    component=".security.GroupsVocabularyFactory"
-    name="plone.app.vocabularies.Groups"
-    />
-
-  <utility
     component=".security.PermissionsVocabularyFactory"
     name="plone.app.vocabularies.Permissions"
     />
@@ -93,8 +88,16 @@
     />
 
   <utility
-    factory=".users.UsersFactory"
+    factory=".principals.UsersFactory"
     name="plone.app.vocabularies.Users"
+    />
+  <utility
+    factory=".principals.GroupsFactory"
+    name="plone.app.vocabularies.Groups"
+    />
+  <utility
+    factory=".principals.PrincipalsFactory"
+    name="plone.app.vocabularies.Principals"
     />
 
   <utility

--- a/plone/app/vocabularies/groups.py
+++ b/plone/app/vocabularies/groups.py
@@ -57,6 +57,9 @@ class GroupsSource(object):
     """
 
     def __init__(self, context):
+        msg = 'GroupsSource is deprecated and will be removed on ' \
+              'Plone 6'
+        warnings.warn(msg, DeprecationWarning)
         self.context = context
         self.users = getToolByName(context, 'acl_users')
 

--- a/plone/app/vocabularies/groups.py
+++ b/plone/app/vocabularies/groups.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# KEPT HERE FOR BBB UNTIL PLONE 6
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.browser.interfaces import ITerms

--- a/plone/app/vocabularies/interfaces.py
+++ b/plone/app/vocabularies/interfaces.py
@@ -55,4 +55,3 @@ class IPermissiveVocabulary(IVocabularyTokenized):
         vocabulary about to be mutated with insertion of a value not
         yet within).
         """
-

--- a/plone/app/vocabularies/principals.py
+++ b/plone/app/vocabularies/principals.py
@@ -11,27 +11,38 @@ from zope.schema.vocabulary import SimpleVocabulary
 
 GETTER = {'user': 'getUserById', 'group': 'getGroupById'}
 
+_USER_SEARCH = {
+    'search': 'searchUsers',
+    # Hint: The fullname search is provided i.e. in IUserEnumeration of
+    # the property plugin in PlonePAS.
+    'searchattr': 'fullname',
+    'searchargs': {'sort_by': 'fullname'},
+    'many': 'plone.many_users',
+}
+_GROUP_SEARCH = {
+    'search': 'searchGroups',
+    # Hint: The fullname search is excluded in i.e. in IUserEnumeration of
+    # the property plugin in PlonePAS. title  is supported.
+    'searchattr': 'title',
+    'searchargs': {'sort_by': 'title'},
+    'many': 'plone.many_groups',
+}
+
 SOURCES = {
     'user': {
-        'search': 'searchUsers',
-        'searchargs': {'sort_by': 'title'},
+        'searches': [_USER_SEARCH],
         'get': 'getUserById',
         'prefix': False,
-        'many': ['plone.many_users'],
     },
     'group': {
-        'search': 'searchGroups',
-        'searchargs': {'sort_by': 'title'},
+        'searches': [_GROUP_SEARCH],
         'get': 'getGroupById',
         'prefix': False,
-        'many': ['plone.many_groups'],
     },
     'principal': {
-        'search': 'searchPrincipals',
-        'searchargs': {'sort_by': 'title', 'groups_first': True},
+        'searches': [_GROUP_SEARCH, _USER_SEARCH],
         'get': 'getPrincipalById',
         'prefix': True,
-        'many': ['plone.many_users', 'plone.many_groups'],
     },
 }
 
@@ -51,21 +62,49 @@ class PrincipalsVocabulary(SimpleVocabulary):
 
     @property
     def _acl_users(self):
-        aclu = getattr(self, "_aclu", None)
+        aclu = getattr(self, '_aclu', None)
         if not aclu:
             aclu = self._aclu = getToolByName(getSite(), 'acl_users')
         return aclu
 
-    def __contains__(self, value):
-        """Checks if the principal exists in PAS, not only in the queried subset
+    def _get_from_source(self, value, default=None):
+        """Helper to get a user or group from users folder.
         """
         if SOURCES[self._principal_source]['prefix']:
+            if ':' not in value:
+                return default
             principal_type, principal_id = value.split(':', 2)
         else:
             principal_type = self._principal_source
             principal_id = value
         getter = getattr(self._acl_users, GETTER[principal_type])
-        return bool(getter(principal_id, None))
+        return getter(principal_id, default)
+
+    def __contains__(self, value):
+        """Checks if the principal exists in current subset or in PAS.
+        """
+        result = super(PrincipalsVocabulary, self).__contains__(value)
+        return result or bool(self._get_from_source(value))
+
+    def getTerm(self, value):
+        """Checks also for values not in the current subset.
+        This allows to lookup already saved values.
+        """
+        try:
+            return super(PrincipalsVocabulary, self).getTerm(value)
+        except LookupError:
+            user = self._get_from_source(value)
+            if user is None:
+                raise
+            if user.isGroup():
+                title = user.getProperty('title', value) or value
+            else:
+                title = user.getProperty('fullname', value) or value
+            if SOURCES[self._principal_source]['prefix']:
+                token = value.replace(':', '__', 1)
+            else:
+                token = value
+            return self.__class__.createTerm(value, token, title)
 
     def __getitem__(self, start, stop=None):
         """Sliceable"""
@@ -84,14 +123,20 @@ class BaseFactory(object):
     """Factory creating a PrincipalsVocabulary
     """
 
+    source = None
+
     def should_search(self, query):
-        ''' Test if we should search for users
-        '''
+        """ Test if we should search for users
+        """
         if query:
             return True
         registry = getUtility(IRegistry)
         return not [
-            x for x in filter(registry.get, SOURCES[self.source]["many"])
+            x
+            for x in filter(
+                registry.get,
+                [cfg['many'] for cfg in SOURCES[self.source]['searches']],
+            )
         ]
 
     def use_principal_triple(self, principal_triple):
@@ -104,7 +149,7 @@ class BaseFactory(object):
             (user__johndoe, user:johndoe, 'John Doe') or
             (group__editors, group:editors, 'Editors').
 
-        Meant to be overriden in subclasses.
+        Meant to be overriden in subclasses for post-filtering result.
         """
         return True
 
@@ -112,20 +157,21 @@ class BaseFactory(object):
         if not self.should_search(query):
             return PrincipalsVocabulary.fromItems([])
         acl_users = getToolByName(context, 'acl_users')
-        search = getattr(acl_users, SOURCES[self.source]['search'])
+        cfg = SOURCES[self.source]
 
         def principal_triples():
-            # TODO: fullname ok here?
-            for info in search(
-                fullname=query, **SOURCES[self.source]['searchargs']
-            ):
-                principal_id = info['id']
-                if SOURCES[self.source]['prefix']:
-                    principal_id = "{0}:{1}".format(
-                        info['principal_type'], principal_id
-                    )
-                principal_token = principal_id.replace(':', '__')
-                yield (principal_token, principal_id, info['title'])
+            for search_cfg in cfg['searches']:
+                search = getattr(acl_users, search_cfg['search'])
+                searchargs = search_cfg['searchargs'].copy()
+                searchargs[search_cfg['searchattr']] = query
+                for info in search(**searchargs):
+                    principal_id = info['id']
+                    if cfg['prefix']:
+                        principal_id = '{0}:{1}'.format(
+                            info['principal_type'], principal_id
+                        )
+                    principal_token = principal_id.replace(':', '__')
+                    yield (principal_token, principal_id, info['title'])
 
         filtered_principal_triples = filter(
             self.use_principal_triple, principal_triples()

--- a/plone/app/vocabularies/principals.py
+++ b/plone/app/vocabularies/principals.py
@@ -153,6 +153,9 @@ class BaseFactory(object):
             (user__johndoe, user:johndoe, 'John Doe') or
             (group__editors, group:editors, 'Editors').
 
+        returns wether the triple shall be included in the vocabulary or not
+        (bool).
+
         Meant to be overriden in subclasses for post-filtering result.
         """
         return True

--- a/plone/app/vocabularies/principals.py
+++ b/plone/app/vocabularies/principals.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+from plone.app.vocabularies.interfaces import ISlicableVocabulary
+from plone.registry.interfaces import IRegistry
+from Products.CMFCore.utils import getToolByName
+from zope.component import getUtility
+from zope.component.hooks import getSite
+from zope.interface import implementer
+from zope.schema.interfaces import IVocabularyFactory
+from zope.schema.vocabulary import SimpleVocabulary
+
+GETTER = {'user': 'getUserById', 'group': 'getGroupById'}
+
+SOURCES = {
+    'user': {
+        'search': 'searchUsers',
+        'searchargs': {'sort_by': 'title'},
+        'get': 'getUserById',
+        'prefix': False,
+        'many': ['plone.many_users'],
+    },
+    'group': {
+        'search': 'searchGroups',
+        'searchargs': {'sort_by': 'title'},
+        'get': 'getGroupById',
+        'prefix': False,
+        'many': ['plone.many_groups'],
+    },
+    'principal': {
+        'search': 'searchPrincipals',
+        'searchargs': {'sort_by': 'title', 'groups_first': True},
+        'get': 'getPrincipalById',
+        'prefix': True,
+        'many': ['plone.many_users', 'plone.many_groups'],
+    },
+}
+
+
+@implementer(ISlicableVocabulary)
+class PrincipalsVocabulary(SimpleVocabulary):
+    """Vocabulary dealing with users/ groups (or in theory any other principal)
+    """
+
+    @property
+    def principal_source(self):
+        return self._principal_source
+
+    @principal_source.setter
+    def principal_source(self, value):
+        self._principal_source = value
+
+    @property
+    def _acl_users(self):
+        aclu = getattr(self, "_aclu", None)
+        if not aclu:
+            aclu = self._aclu = getToolByName(getSite(), 'acl_users')
+        return aclu
+
+    def __contains__(self, value):
+        """Checks if the principal exists in PAS, not only in the queried subset
+        """
+        if SOURCES[self._principal_source]['prefix']:
+            principal_type, principal_id = value.split(':', 2)
+        else:
+            principal_type = self._principal_source
+            principal_id = value
+        getter = getattr(self._acl_users, GETTER[principal_type])
+        return bool(getter(principal_id, None))
+
+    def __getitem__(self, start, stop=None):
+        """Sliceable"""
+        if isinstance(start, slice):
+            slice_inst = start
+            start = slice_inst.start
+            stop = slice_inst.stop
+        elif not stop:
+            return self._terms[start]
+
+        # sliced up
+        return self._terms[start:stop]
+
+
+class BaseFactory(object):
+    """Factory creating a PrincipalsVocabulary
+    """
+
+    def should_search(self, query):
+        ''' Test if we should search for users
+        '''
+        if query:
+            return True
+        registry = getUtility(IRegistry)
+        return not [
+            x for x in filter(registry.get, SOURCES[self.source]["many"])
+        ]
+
+    def use_principal_triple(self, principal_triple):
+        """Used by ``functools.filter`` to decide if the triple should be used.
+
+        principal_triple
+            A triple (token, value, title).
+            Like (johndoe, johndoe, 'John Doe') (unprefixed).
+            Value might be a prefixed Id by principal_type, like
+            (user__johndoe, user:johndoe, 'John Doe') or
+            (group__editors, group:editors, 'Editors').
+
+        Meant to be overriden in subclasses.
+        """
+        return True
+
+    def __call__(self, context, query=''):
+        if not self.should_search(query):
+            return PrincipalsVocabulary.fromItems([])
+        acl_users = getToolByName(context, 'acl_users')
+        search = getattr(acl_users, SOURCES[self.source]['search'])
+
+        def principal_triples():
+            # TODO: fullname ok here?
+            for info in search(
+                fullname=query, **SOURCES[self.source]['searchargs']
+            ):
+                principal_id = info['id']
+                if SOURCES[self.source]['prefix']:
+                    principal_id = "{0}:{1}".format(
+                        info['principal_type'], principal_id
+                    )
+                principal_token = principal_id.replace(':', '__')
+                yield (principal_token, principal_id, info['title'])
+
+        filtered_principal_triples = filter(
+            self.use_principal_triple, principal_triples()
+        )
+        vocabulary = PrincipalsVocabulary.fromItems(filtered_principal_triples)
+        vocabulary.principal_source = self.source
+        return vocabulary
+
+
+@implementer(IVocabularyFactory)
+class PrincipalsFactory(BaseFactory):
+    source = 'principal'
+
+
+@implementer(IVocabularyFactory)
+class UsersFactory(BaseFactory):
+    source = 'user'
+
+
+@implementer(IVocabularyFactory)
+class GroupsFactory(BaseFactory):
+    source = 'group'

--- a/plone/app/vocabularies/principals.py
+++ b/plone/app/vocabularies/principals.py
@@ -8,6 +8,7 @@ from zope.interface import implementer
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleVocabulary
 
+
 GETTER = {'user': 'getUserById', 'group': 'getGroupById'}
 
 SOURCES = {

--- a/plone/app/vocabularies/principals.py
+++ b/plone/app/vocabularies/principals.py
@@ -47,6 +47,10 @@ SOURCES = {
 }
 
 
+def _get_acl_users():
+    return getToolByName(getSite(), 'acl_users')
+
+
 @implementer(ISlicableVocabulary)
 class PrincipalsVocabulary(SimpleVocabulary):
     """Vocabulary dealing with users/ groups (or in theory any other principal)
@@ -64,7 +68,7 @@ class PrincipalsVocabulary(SimpleVocabulary):
     def _acl_users(self):
         aclu = getattr(self, '_aclu', None)
         if not aclu:
-            aclu = self._aclu = getToolByName(getSite(), 'acl_users')
+            aclu = self._aclu = _get_acl_users()
         return aclu
 
     def _get_from_source(self, value, default=None):
@@ -156,7 +160,7 @@ class BaseFactory(object):
     def __call__(self, context, query=''):
         if not self.should_search(query):
             return PrincipalsVocabulary.fromItems([])
-        acl_users = getToolByName(context, 'acl_users')
+        acl_users = _get_acl_users()
         cfg = SOURCES[self.source]
 
         def principal_triples():

--- a/plone/app/vocabularies/security.py
+++ b/plone/app/vocabularies/security.py
@@ -10,6 +10,13 @@ from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
 from zope.site.hooks import getSite
 
+import zope.deferredimport
+
+zope.deferredimport.deprecated(
+    "Import from plone.app.vocabularies.principals instead",
+    GroupsFactory='plone.app.vocabularies:principals.GroupsFactory',
+    GroupsVocabulary='plone.app.vocabularies:principals.GroupsVocabulary',
+)
 
 PMF = MessageFactory('plone')
 
@@ -70,66 +77,8 @@ class RolesVocabulary(object):
 
         return SimpleVocabulary(items)
 
+
 RolesVocabularyFactory = RolesVocabulary()
-
-
-@implementer(IVocabularyFactory)
-class GroupsVocabulary(object):
-    """Vocabulary factory for groups in the portal
-
-      >>> from zope.component import queryUtility
-      >>> from plone.app.vocabularies.tests.base import create_context
-      >>> from plone.app.vocabularies.tests.base import DummyTool
-
-      >>> name = 'plone.app.vocabularies.Groups'
-      >>> util = queryUtility(IVocabularyFactory, name)
-      >>> context = create_context()
-
-      >>> len(util(context))
-      0
-
-      >>> class DummyGroup(object):
-      ...     def __init__(self, id, name):
-      ...         self.id = id
-      ...         self.name = name
-      ...
-      ...     def getGroupId(self):
-      ...         return self.id
-      ...
-      ...     def getGroupTitleOrName(self):
-      ...         return self.name
-
-      >>> tool = DummyTool('portal_groups')
-      >>> def listGroups():
-      ...     return (DummyGroup('editors', 'Editors'),
-      ...             DummyGroup('viewers', 'Viewers'))
-      >>> tool.listGroups = listGroups
-      >>> context.portal_groups = tool
-
-      >>> groups = util(context)
-      >>> groups
-      <zope.schema.vocabulary.SimpleVocabulary object at ...>
-
-      >>> len(groups.by_token)
-      2
-
-      >>> editors = groups.by_token['editors']
-      >>> editors.title, editors.token, editors.value
-      ('Editors', 'editors', 'editors')
-    """
-
-    def __call__(self, context):
-        items = []
-        site = getSite()
-        gtool = getToolByName(site, 'portal_groups', None)
-        if gtool is not None:
-            groups = gtool.listGroups()
-            items = [(g.getGroupId(), g.getGroupTitleOrName()) for g in groups]
-            items.sort()
-            items = [SimpleTerm(i[0], i[0], i[1]) for i in items]
-        return SimpleVocabulary(items)
-
-GroupsVocabularyFactory = GroupsVocabulary()
 
 
 @implementer(IVocabularyFactory)
@@ -142,5 +91,6 @@ class PermissionsVocabulary(object):
         items = [SimpleTerm(perm, perm, perm)
                  for perm in site.possible_permissions()]
         return SimpleVocabulary(items)
+
 
 PermissionsVocabularyFactory = PermissionsVocabulary()

--- a/plone/app/vocabularies/security.py
+++ b/plone/app/vocabularies/security.py
@@ -12,6 +12,7 @@ from zope.site.hooks import getSite
 
 import zope.deferredimport
 
+
 zope.deferredimport.deprecated(
     "Import from plone.app.vocabularies.principals instead",
     GroupsFactory='plone.app.vocabularies:principals.GroupsFactory',

--- a/plone/app/vocabularies/syndication.py
+++ b/plone/app/vocabularies/syndication.py
@@ -11,6 +11,7 @@ from zope.schema.vocabulary import SimpleVocabulary
 
 import six
 
+
 try:
     # XXX: this is a circular dependency (not declared in setup.py)
     from Products.CMFPlone.interfaces.syndication import ISiteSyndicationSettings  # noqa

--- a/plone/app/vocabularies/tests/test_principals.py
+++ b/plone/app/vocabularies/tests/test_principals.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from plone.app.vocabularies.testing import PAVocabularies_INTEGRATION_TESTING
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
+from zope.schema.interfaces import IVocabularyFactory
+
+import unittest
+
+
+class TimezoneTest(unittest.TestCase):
+    layer = PAVocabularies_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+

--- a/plone/app/vocabularies/tests/test_principals.py
+++ b/plone/app/vocabularies/tests/test_principals.py
@@ -1,14 +1,372 @@
 # -*- coding: utf-8 -*-
 from plone.app.vocabularies.testing import PAVocabularies_INTEGRATION_TESTING
-from plone.registry.interfaces import IRegistry
-from zope.component import getUtility
-from zope.schema.interfaces import IVocabularyFactory
-
 import unittest
 
 
-class TimezoneTest(unittest.TestCase):
+class PrincipalsTest(unittest.TestCase):
     layer = PAVocabularies_INTEGRATION_TESTING
 
     def setUp(self):
         self.portal = self.layer['portal']
+
+    def _make_user(self, userid, fullname):
+        user = self.portal['acl_users']._doAddUser(
+            userid, 'secret', ['Member'], []
+        )
+        user.setProperties(fullname=fullname)
+
+    def _make_group(self, groupid, title):
+        self.portal['acl_users']._doAddGroup(groupid, [], title=title)
+
+    def test_empty_principals_vocabulary(self):
+        from plone.app.vocabularies.principals import PrincipalsVocabulary
+
+        vocab = PrincipalsVocabulary([])
+        vocab.principal_source = 'user'
+
+        # basic data
+        self.assertEqual(vocab.principal_source, 'user')
+        self.assertEqual(vocab._acl_users, self.portal['acl_users'])
+
+    def test_pas_connectivity_user(self):
+        self._make_user('user1', 'User One')
+
+        from plone.app.vocabularies.principals import PrincipalsVocabulary
+
+        vocab = PrincipalsVocabulary([])
+        vocab.principal_source = 'user'
+
+        # test 1
+        vuser = vocab._get_from_source('user1')
+        self.assertEqual(vuser.getId(), 'user1')
+
+        # test 2
+        term = vocab.getTerm('user1')
+        self.assertEqual(term.value, 'user1')
+        self.assertEqual(term.token, 'user1')
+        self.assertEqual(term.title, 'User One')
+        with self.assertRaises(LookupError):
+            term = vocab.getTerm('user:non-existing')
+        with self.assertRaises(LookupError):
+            term = vocab.getTerm('non-existing')
+
+    def test_pas_connectivity_group(self):
+        self._make_group('group1', 'Group One')
+
+        from plone.app.vocabularies.principals import PrincipalsVocabulary
+
+        vocab = PrincipalsVocabulary([])
+        vocab.principal_source = 'group'
+
+        # test 1
+        vgroup = vocab._get_from_source('group1')
+        self.assertEqual(vgroup.getId(), 'group1')
+
+        # test 2
+        term = vocab.getTerm('group1')
+        self.assertEqual(term.value, 'group1')
+        self.assertEqual(term.token, 'group1')
+        self.assertEqual(term.title, 'Group One')
+        with self.assertRaises(LookupError):
+            term = vocab.getTerm('group:non-existing')
+        with self.assertRaises(LookupError):
+            term = vocab.getTerm('non-existing')
+
+    def test_pas_connectivity_principal(self):
+        self._make_user('user1', 'User One')
+        self._make_group('group1', 'Group One')
+
+        from plone.app.vocabularies.principals import PrincipalsVocabulary
+
+        vocab = PrincipalsVocabulary([])
+        vocab.principal_source = 'principal'
+
+        # test 1
+        vgroup = vocab._get_from_source('user:user1')
+        self.assertEqual(vgroup.getId(), 'user1')
+        vgroup = vocab._get_from_source('group:group1')
+        self.assertEqual(vgroup.getId(), 'group1')
+
+        # test 2
+        term = vocab.getTerm('user:user1')
+        self.assertEqual(term.value, 'user:user1')
+        self.assertEqual(term.token, 'user__user1')
+        self.assertEqual(term.title, 'User One')
+        term = vocab.getTerm('group:group1')
+        self.assertEqual(term.value, 'group:group1')
+        self.assertEqual(term.token, 'group__group1')
+        self.assertEqual(term.title, 'Group One')
+        with self.assertRaises(LookupError):
+            term = vocab.getTerm('user:non-existing')
+        with self.assertRaises(LookupError):
+            term = vocab.getTerm('group:non-existing')
+        with self.assertRaises(LookupError):
+            term = vocab.getTerm('non-existing')
+
+    def test_populated_user(self):
+        from zope.schema.vocabulary import SimpleTerm
+
+        terms = [
+            SimpleTerm(
+                'user_{0}'.format(idx),
+                'user{0}'.format(idx),
+                'User {0}'.format(idx),
+            )
+            for idx in range(0, 10)
+        ]
+
+        from plone.app.vocabularies.principals import PrincipalsVocabulary
+
+        vocab = PrincipalsVocabulary(terms)
+        vocab.principal_source = 'user'
+
+        self.assertEqual(vocab.getTerm('user_3').value, 'user_3')
+        self.assertEqual(vocab.getTerm('user_3').token, 'user3')
+        self.assertEqual(vocab.getTerm('user_3').title, 'User 3')
+
+        self.assertEqual(vocab.getTermByToken('user3').value, 'user_3')
+        self.assertEqual(vocab.getTermByToken('user3').token, 'user3')
+        self.assertEqual(vocab.getTermByToken('user3').title, 'User 3')
+
+        self.assertEqual(vocab[6].value, 'user_6')
+        self.assertEqual(
+            ['user_2', 'user_3', 'user_4', 'user_5'],
+            [term.value for term in vocab[2:6]],
+        )
+
+        self.assertTrue('user_2' in vocab)
+        self.assertFalse('non-existing' in vocab)
+
+    def test_populated_group(self):
+        from zope.schema.vocabulary import SimpleTerm
+
+        terms = [
+            SimpleTerm(
+                'group_{0}'.format(idx),
+                'group{0}'.format(idx),
+                'Group {0}'.format(idx),
+            )
+            for idx in range(0, 10)
+        ]
+
+        from plone.app.vocabularies.principals import PrincipalsVocabulary
+
+        vocab = PrincipalsVocabulary(terms)
+        vocab.principal_source = 'group'
+
+        self.assertEqual(vocab.getTerm('group_3').value, 'group_3')
+        self.assertEqual(vocab.getTerm('group_3').token, 'group3')
+        self.assertEqual(vocab.getTerm('group_3').title, 'Group 3')
+
+        self.assertEqual(vocab.getTermByToken('group3').value, 'group_3')
+        self.assertEqual(vocab.getTermByToken('group3').token, 'group3')
+        self.assertEqual(vocab.getTermByToken('group3').title, 'Group 3')
+
+        self.assertEqual(vocab[6].value, 'group_6')
+        self.assertEqual(
+            ['group_2', 'group_3', 'group_4', 'group_5'],
+            [term.value for term in vocab[2:6]],
+        )
+
+        self.assertTrue('group_2' in vocab)
+        self.assertFalse('non-existing' in vocab)
+
+    def test_populated_principals(self):
+        from zope.schema.vocabulary import SimpleTerm
+
+        terms = [
+            SimpleTerm(
+                'user:user_{0}'.format(idx),
+                'user__user{0}'.format(idx),
+                'User {0}'.format(idx),
+            )
+            for idx in range(0, 10)
+        ]
+        terms += [
+            SimpleTerm(
+                'group:group_{0}'.format(idx),
+                'group__group{0}'.format(idx),
+                'Group {0}'.format(idx),
+            )
+            for idx in range(0, 10)
+        ]
+
+        from plone.app.vocabularies.principals import PrincipalsVocabulary
+
+        vocab = PrincipalsVocabulary(terms)
+        vocab.principal_source = 'principal'
+
+        # users
+        self.assertEqual(vocab.getTerm('user:user_4').value, 'user:user_4')
+        self.assertEqual(vocab.getTerm('user:user_3').token, 'user__user3')
+        self.assertEqual(vocab.getTerm('user:user_6').title, 'User 6')
+
+        self.assertEqual(
+            vocab.getTermByToken('user__user4').value, 'user:user_4'
+        )
+        self.assertEqual(
+            vocab.getTermByToken('user__user3').token, 'user__user3'
+        )
+        self.assertEqual(vocab.getTermByToken('user__user6').title, 'User 6')
+
+        self.assertTrue('user:user_2' in vocab)
+        self.assertFalse('non-existing' in vocab)
+
+        # groups
+        self.assertEqual(vocab.getTerm('group:group_3').value, 'group:group_3')
+        self.assertEqual(vocab.getTerm('group:group_3').token, 'group__group3')
+        self.assertEqual(vocab.getTerm('group:group_3').title, 'Group 3')
+
+        self.assertEqual(
+            vocab.getTermByToken('group__group3').value, 'group:group_3'
+        )
+        self.assertEqual(
+            vocab.getTermByToken('group__group3').token, 'group__group3'
+        )
+        self.assertEqual(
+            vocab.getTermByToken('group__group3').title, 'Group 3'
+        )
+
+        # getitem/slice
+        self.assertEqual(vocab[6].value, 'user:user_6')
+        self.assertEqual(
+            ['group:group_7', 'group:group_8', 'group:group_9'],
+            [term.value for term in vocab[17:]],
+        )
+        self.assertEqual(
+            ['user:user_8', 'user:user_9', 'group:group_0'],
+            [term.value for term in vocab[8:11]],
+        )
+
+        # contains
+        self.assertTrue('group:group_2' in vocab)
+        self.assertFalse('non-existing' in vocab)
+
+    def test_factory_user_blank(self):
+        for idx in range(0, 10):
+            # creates user0: 'Abc User'; user1, 'Bcd User', ...
+            userid = 'user{0}'.format(idx)
+            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' User'
+            self._make_user(userid, fullname)
+
+        from plone.app.vocabularies.principals import UsersFactory
+
+        factory = UsersFactory()
+        vocab = factory(self.portal)
+        self.assertEqual(vocab.getTerm('user0').title, 'Abc User')
+        self.assertEqual(vocab.getTerm('user2').title, 'Cde User')
+
+    def test_factory_user_query(self):
+        for idx in range(0, 10):
+            # creates user0: 'Abc User'; user1, 'Bcd User', ...
+            userid = 'user{0}'.format(idx)
+            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' User'
+            self._make_user(userid, fullname)
+
+        from plone.app.vocabularies.principals import UsersFactory
+
+        factory = UsersFactory()
+        vocab = factory(self.portal, query='Cde')
+
+        # reduced by query
+        self.assertEqual([term.value for term in vocab], ['user2'])
+
+        # but getTerm still works for all
+        self.assertEqual(vocab.getTerm('user0').title, 'Abc User')
+        self.assertEqual(vocab.getTerm('user2').title, 'Cde User')
+
+        # contains works too
+        self.assertTrue('user0' in vocab)
+        self.assertTrue('user2' in vocab)
+
+    def test_factory_group_blank(self):
+        for idx in range(0, 10):
+            # creates group0: 'Abc Group'; group1, 'Bcd Group', ...
+            groupid = 'group{0}'.format(idx)
+            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' Group'
+            self._make_group(groupid, fullname)
+
+        from plone.app.vocabularies.principals import GroupsFactory
+
+        factory = GroupsFactory()
+        vocab = factory(self.portal)
+        self.assertEqual(vocab.getTerm('group0').title, 'Abc Group')
+        self.assertEqual(vocab.getTerm('group2').title, 'Cde Group')
+
+    def test_factory_group_query(self):
+        for idx in range(0, 10):
+            # creates user0: 'Abc User'; user1, 'Bcd User', ...
+            groupid = 'group{0}'.format(idx)
+            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' Group'
+            self._make_group(groupid, fullname)
+
+        from plone.app.vocabularies.principals import GroupsFactory
+
+        factory = GroupsFactory()
+        vocab = factory(self.portal, query='Cde')
+
+        # reduced by query
+        self.assertEqual([term.value for term in vocab], ['group2'])
+
+        # but getTerm still works for all
+        self.assertEqual(vocab.getTerm('group0').title, 'Abc Group')
+        self.assertEqual(vocab.getTerm('group2').title, 'Cde Group')
+
+        # contains works too
+        self.assertTrue('group0' in vocab)
+        self.assertTrue('group2' in vocab)
+
+    def test_factory_principal_blank(self):
+        for idx in range(0, 10):
+            # creates user0: 'Abc User'; user1, 'Bcd User', ...
+            userid = 'user{0}'.format(idx)
+            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' User'
+            self._make_user(userid, fullname)
+        for idx in range(0, 10):
+            # creates group0: 'Abc Group'; group1, 'Bcd Group', ...
+            groupid = 'group{0}'.format(idx)
+            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' Group'
+            self._make_group(groupid, fullname)
+
+        from plone.app.vocabularies.principals import PrincipalsFactory
+
+        factory = PrincipalsFactory()
+        vocab = factory(self.portal)
+        self.assertEqual(vocab.getTerm('user:user0').title, 'Abc User')
+        self.assertEqual(vocab.getTerm('user:user2').title, 'Cde User')
+        self.assertEqual(vocab.getTerm('group:group0').title, 'Abc Group')
+        self.assertEqual(vocab.getTerm('group:group2').title, 'Cde Group')
+
+    def test_factory_principal_query(self):
+        for idx in range(0, 10):
+            # creates user0: 'Abc User'; user1, 'Bcd User', ...
+            userid = 'user{0}'.format(idx)
+            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' User'
+            self._make_user(userid, fullname)
+        for idx in range(0, 10):
+            # creates group0: 'Abc Group'; group1, 'Bcd Group', ...
+            groupid = 'group{0}'.format(idx)
+            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' Group'
+            self._make_group(groupid, fullname)
+
+        from plone.app.vocabularies.principals import PrincipalsFactory
+
+        factory = PrincipalsFactory()
+        vocab = factory(self.portal, query='Cde')
+
+        # reduced by query
+        self.assertEqual(
+            [term.value for term in vocab], ['group:group2', 'user:user2']
+        )
+
+        # but getTerm still works for all
+        self.assertEqual(vocab.getTerm('user:user0').title, 'Abc User')
+        self.assertEqual(vocab.getTerm('user:user2').title, 'Cde User')
+        self.assertEqual(vocab.getTerm('group:group0').title, 'Abc Group')
+        self.assertEqual(vocab.getTerm('group:group2').title, 'Cde Group')
+
+        # contains works too
+        self.assertTrue('user:user0' in vocab)
+        self.assertTrue('user:user2' in vocab)
+        self.assertTrue('group:group0' in vocab)
+        self.assertTrue('group:group2' in vocab)

--- a/plone/app/vocabularies/tests/test_principals.py
+++ b/plone/app/vocabularies/tests/test_principals.py
@@ -12,4 +12,3 @@ class TimezoneTest(unittest.TestCase):
 
     def setUp(self):
         self.portal = self.layer['portal']
-

--- a/plone/app/vocabularies/tests/test_principals.py
+++ b/plone/app/vocabularies/tests/test_principals.py
@@ -38,7 +38,7 @@ class PrincipalsTest(unittest.TestCase):
         vocab.principal_source = 'user'
 
         # test 1
-        vuser = vocab._get_from_source('user1')
+        vuser = vocab._get_principal_from_source('user1')
         self.assertEqual(vuser.getId(), 'user1')
 
         # test 2
@@ -60,7 +60,7 @@ class PrincipalsTest(unittest.TestCase):
         vocab.principal_source = 'group'
 
         # test 1
-        vgroup = vocab._get_from_source('group1')
+        vgroup = vocab._get_principal_from_source('group1')
         self.assertEqual(vgroup.getId(), 'group1')
 
         # test 2
@@ -83,9 +83,9 @@ class PrincipalsTest(unittest.TestCase):
         vocab.principal_source = 'principal'
 
         # test 1
-        vgroup = vocab._get_from_source('user:user1')
+        vgroup = vocab._get_principal_from_source('user:user1')
         self.assertEqual(vgroup.getId(), 'user1')
-        vgroup = vocab._get_from_source('group:group1')
+        vgroup = vocab._get_principal_from_source('group:group1')
         self.assertEqual(vgroup.getId(), 'group1')
 
         # test 2
@@ -239,29 +239,31 @@ class PrincipalsTest(unittest.TestCase):
             [term.value for term in vocab[8:11]],
         )
 
-        # contains
+        # contains works too (by token)
         self.assertTrue('group:group_2' in vocab)
         self.assertFalse('non-existing' in vocab)
 
     def test_factory_user_blank(self):
         for idx in range(0, 10):
             # creates user0: 'Abc User'; user1, 'Bcd User', ...
-            userid = 'user{0}'.format(idx)
-            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' User'
+            userid = 'usér{0}'.format(idx)
+            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' Üser'
             self._make_user(userid, fullname)
 
         from plone.app.vocabularies.principals import UsersFactory
 
         factory = UsersFactory()
         vocab = factory(self.portal)
-        self.assertEqual(vocab.getTerm('user0').title, 'Abc User')
-        self.assertEqual(vocab.getTerm('user2').title, 'Cde User')
+        self.assertEqual(vocab.getTerm('usér0').title, 'Abc Üser')
+        self.assertEqual(vocab.getTerm('usér2').title, 'Cde Üser')
+        self.assertEqual(vocab.getTermByToken('usér0').title, 'Abc Üser')
+        self.assertEqual(vocab.getTermByToken('usér2').title, 'Cde Üser')
 
     def test_factory_user_query(self):
         for idx in range(0, 10):
             # creates user0: 'Abc User'; user1, 'Bcd User', ...
-            userid = 'user{0}'.format(idx)
-            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' User'
+            userid = 'usér{0}'.format(idx)
+            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' Üser'
             self._make_user(userid, fullname)
 
         from plone.app.vocabularies.principals import UsersFactory
@@ -270,35 +272,39 @@ class PrincipalsTest(unittest.TestCase):
         vocab = factory(self.portal, query='Cde')
 
         # reduced by query
-        self.assertEqual([term.value for term in vocab], ['user2'])
+        self.assertEqual([term.value for term in vocab], ['usér2'])
 
-        # but getTerm still works for all
-        self.assertEqual(vocab.getTerm('user0').title, 'Abc User')
-        self.assertEqual(vocab.getTerm('user2').title, 'Cde User')
+        # getTerm[ByToken] still works for all
+        self.assertEqual(vocab.getTerm('usér0').title, 'Abc Üser')
+        self.assertEqual(vocab.getTerm('usér2').title, 'Cde Üser')
+        self.assertEqual(vocab.getTermByToken('usér0').title, 'Abc Üser')
+        self.assertEqual(vocab.getTermByToken('usér2').title, 'Cde Üser')
 
-        # contains works too
-        self.assertTrue('user0' in vocab)
-        self.assertTrue('user2' in vocab)
+        # contains works (by value)
+        self.assertTrue('usér0' in vocab)
+        self.assertTrue('usér2' in vocab)
 
     def test_factory_group_blank(self):
         for idx in range(0, 10):
             # creates group0: 'Abc Group'; group1, 'Bcd Group', ...
-            groupid = 'group{0}'.format(idx)
-            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' Group'
+            groupid = 'groüp{0}'.format(idx)
+            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' Gröüp'
             self._make_group(groupid, fullname)
 
         from plone.app.vocabularies.principals import GroupsFactory
 
         factory = GroupsFactory()
         vocab = factory(self.portal)
-        self.assertEqual(vocab.getTerm('group0').title, 'Abc Group')
-        self.assertEqual(vocab.getTerm('group2').title, 'Cde Group')
+        self.assertEqual(vocab.getTerm('groüp0').title, 'Abc Gröüp')
+        self.assertEqual(vocab.getTerm('groüp2').title, 'Cde Gröüp')
+        self.assertEqual(vocab.getTermByToken('groüp0').title, 'Abc Gröüp')
+        self.assertEqual(vocab.getTermByToken('groüp2').title, 'Cde Gröüp')
 
     def test_factory_group_query(self):
         for idx in range(0, 10):
             # creates user0: 'Abc User'; user1, 'Bcd User', ...
-            groupid = 'group{0}'.format(idx)
-            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' Group'
+            groupid = 'groüp{0}'.format(idx)
+            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' Gröüp'
             self._make_group(groupid, fullname)
 
         from plone.app.vocabularies.principals import GroupsFactory
@@ -307,47 +313,53 @@ class PrincipalsTest(unittest.TestCase):
         vocab = factory(self.portal, query='Cde')
 
         # reduced by query
-        self.assertEqual([term.value for term in vocab], ['group2'])
+        self.assertEqual([term.value for term in vocab], ['groüp2'])
 
-        # but getTerm still works for all
-        self.assertEqual(vocab.getTerm('group0').title, 'Abc Group')
-        self.assertEqual(vocab.getTerm('group2').title, 'Cde Group')
+        # getTerm[ByToken] still works for all
+        self.assertEqual(vocab.getTerm('groüp0').title, 'Abc Gröüp')
+        self.assertEqual(vocab.getTerm('groüp2').title, 'Cde Gröüp')
+        self.assertEqual(vocab.getTermByToken('groüp0').title, 'Abc Gröüp')
+        self.assertEqual(vocab.getTermByToken('groüp2').title, 'Cde Gröüp')
 
-        # contains works too
-        self.assertTrue('group0' in vocab)
-        self.assertTrue('group2' in vocab)
+        # contains works too (by token)
+        self.assertTrue('groüp0' in vocab)
+        self.assertTrue('groüp2' in vocab)
 
     def test_factory_principal_blank(self):
         for idx in range(0, 10):
             # creates user0: 'Abc User'; user1, 'Bcd User', ...
-            userid = 'user{0}'.format(idx)
-            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' User'
+            userid = 'usér{0}'.format(idx)
+            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' Üser'
             self._make_user(userid, fullname)
         for idx in range(0, 10):
             # creates group0: 'Abc Group'; group1, 'Bcd Group', ...
-            groupid = 'group{0}'.format(idx)
-            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' Group'
+            groupid = 'groüp{0}'.format(idx)
+            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' Gröüp'
             self._make_group(groupid, fullname)
 
         from plone.app.vocabularies.principals import PrincipalsFactory
 
         factory = PrincipalsFactory()
         vocab = factory(self.portal)
-        self.assertEqual(vocab.getTerm('user:user0').title, 'Abc User')
-        self.assertEqual(vocab.getTerm('user:user2').title, 'Cde User')
-        self.assertEqual(vocab.getTerm('group:group0').title, 'Abc Group')
-        self.assertEqual(vocab.getTerm('group:group2').title, 'Cde Group')
+        self.assertEqual(vocab.getTerm('user:usér0').title, 'Abc Üser')
+        self.assertEqual(vocab.getTerm('user:usér2').title, 'Cde Üser')
+        self.assertEqual(vocab.getTerm('group:groüp0').title, 'Abc Gröüp')
+        self.assertEqual(vocab.getTerm('group:groüp2').title, 'Cde Gröüp')
+        self.assertEqual(vocab.getTermByToken('user__usér0').title, 'Abc Üser')
+        self.assertEqual(vocab.getTermByToken('user__usér2').title, 'Cde Üser')
+        self.assertEqual(vocab.getTermByToken('group__groüp0').title, 'Abc Gröüp')
+        self.assertEqual(vocab.getTermByToken('group__groüp2').title, 'Cde Gröüp')
 
     def test_factory_principal_query(self):
         for idx in range(0, 10):
             # creates user0: 'Abc User'; user1, 'Bcd User', ...
-            userid = 'user{0}'.format(idx)
-            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' User'
+            userid = 'usér{0}'.format(idx)
+            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' Üser'
             self._make_user(userid, fullname)
         for idx in range(0, 10):
             # creates group0: 'Abc Group'; group1, 'Bcd Group', ...
-            groupid = 'group{0}'.format(idx)
-            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' Group'
+            groupid = 'groüp{0}'.format(idx)
+            fullname = chr(65 + idx) + chr(98 + idx) + chr(99 + idx) + ' Gröüp'
             self._make_group(groupid, fullname)
 
         from plone.app.vocabularies.principals import PrincipalsFactory
@@ -357,17 +369,21 @@ class PrincipalsTest(unittest.TestCase):
 
         # reduced by query
         self.assertEqual(
-            [term.value for term in vocab], ['group:group2', 'user:user2']
+            [term.value for term in vocab], ['group:groüp2', 'user:usér2']
         )
 
-        # but getTerm still works for all
-        self.assertEqual(vocab.getTerm('user:user0').title, 'Abc User')
-        self.assertEqual(vocab.getTerm('user:user2').title, 'Cde User')
-        self.assertEqual(vocab.getTerm('group:group0').title, 'Abc Group')
-        self.assertEqual(vocab.getTerm('group:group2').title, 'Cde Group')
+        # getTerm still works for all
+        self.assertEqual(vocab.getTerm('user:usér0').title, 'Abc Üser')
+        self.assertEqual(vocab.getTerm('user:usér2').title, 'Cde Üser')
+        self.assertEqual(vocab.getTerm('group:groüp0').title, 'Abc Gröüp')
+        self.assertEqual(vocab.getTerm('group:groüp2').title, 'Cde Gröüp')
+        self.assertEqual(vocab.getTermByToken('user__usér0').title, 'Abc Üser')
+        self.assertEqual(vocab.getTermByToken('user__usér2').title, 'Cde Üser')
+        self.assertEqual(vocab.getTermByToken('group__groüp0').title, 'Abc Gröüp')
+        self.assertEqual(vocab.getTermByToken('group__groüp2').title, 'Cde Gröüp')
 
-        # contains works too
-        self.assertTrue('user:user0' in vocab)
-        self.assertTrue('user:user2' in vocab)
-        self.assertTrue('group:group0' in vocab)
-        self.assertTrue('group:group2' in vocab)
+        # contains works (by token)
+        self.assertTrue('user:usér0' in vocab)
+        self.assertTrue('user:usér2' in vocab)
+        self.assertTrue('group:groüp0' in vocab)
+        self.assertTrue('group:groüp2' in vocab)

--- a/plone/app/vocabularies/tests/test_principals.py
+++ b/plone/app/vocabularies/tests/test_principals.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from plone.app.vocabularies.testing import PAVocabularies_INTEGRATION_TESTING
+
 import unittest
 
 

--- a/plone/app/vocabularies/tests/test_vocabularies.py
+++ b/plone/app/vocabularies/tests/test_vocabularies.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from doctest import DocTestSuite
+from zope.component import hooks
 from zope.component.testing import setUp
 from zope.component.testing import tearDown
 from zope.configuration.xmlconfig import XMLConfig
-from zope.component import hooks
 
 import doctest
 import re

--- a/plone/app/vocabularies/tests/test_vocabularies.py
+++ b/plone/app/vocabularies/tests/test_vocabularies.py
@@ -3,7 +3,7 @@ from doctest import DocTestSuite
 from zope.component.testing import setUp
 from zope.component.testing import tearDown
 from zope.configuration.xmlconfig import XMLConfig
-from zope.site import hooks
+from zope.component import hooks
 
 import doctest
 import re

--- a/plone/app/vocabularies/users.py
+++ b/plone/app/vocabularies/users.py
@@ -12,6 +12,7 @@ import six
 import warnings
 import zope.deferredimport
 
+
 zope.deferredimport.deprecated(
     "Import from plone.app.vocabularies.principals instead",
     UsersFactory='plone.app.vocabularies:principals.UsersFactory',

--- a/plone/app/vocabularies/users.py
+++ b/plone/app/vocabularies/users.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# KEPT HERE FOR BBB UNTIL PLONE 6
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.browser.interfaces import ITerms

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,7 @@ showcontent = true
 directory = "bugfix"
 name = "Bug fixes:"
 showcontent = true
+
+[tool.black]
+line-length = 79
+skip-string-normalization = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,11 @@
 [bdist_wheel]
 universal = 1
+
+[isort]
+force_alphabetical_sort = True
+force_single_line = True
+lines_after_imports = 2
+line_length = 79
+not_skip = __init__.py
+use_parentheses = True
+multi_line_output = 3

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = '4.0.8.dev0'
+version = '4.1.0.dev0'
 
 setup(
     name='plone.app.vocabularies',
@@ -16,10 +16,12 @@ setup(
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Plone',
+        'Framework :: Plone :: Core',
         'Framework :: Plone :: 5.0',
         'Framework :: Plone :: 5.1',
         'Framework :: Plone :: 5.2',
         'Framework :: Zope2',
+        'Framework :: Zope :: 2',
         'Framework :: Zope :: 4',
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
         'Operating System :: OS Independent',


### PR DESCRIPTION
- [x] a complete overhaul of the groups-vocabulary ``plone.app.vocabularies.Groups``, 
- [x] a refined version of the users-vocabulary ``plone.app.vocabularies.Users``
- [x] a new principals vocabulary combining users and groups ``plone.app.vocabularies.Principals``.
- [x] ability to apply a filter to the vocabularies in subclasses
- [x] moved all to ``principals.py``, bbb import are in place (``user.py``, ``security,py``)
- [x] deprecated the ``UserSource`` and ``GroupsSource`` implementations
- [x] documented all in ``README.rst``
- [x] move doctests to unittests
- [x] write new tests for combined principal vocabulary 

Benefits: 
- 200x faster validation of groups
- less and cleaner code
- unified code for all three vocabularies
- filterabilty 