### PR TITLE
Raise LookupError when no content is found for uuid 

### DIFF
--- a/plone/app/vocabularies/catalog.py
+++ b/plone/app/vocabularies/catalog.py
@@ -604,6 +604,8 @@ class CatalogVocabulary(SlicableVocabulary):
             value = IUUID(value)
         query = {'UID': value}
         brains = self.catalog(**query)
+        if not brains:
+            raise LookupError
         for b in brains:
             return self.createTerm(b, None)
 


### PR DESCRIPTION
To fulfill the contract of ITerms.getTerm. The Error is handled in DataConverter. 

Fixes #70