### PR TITLE
Fix a circular dependency to plone.app.querystring

### DIFF
--- a/news/fix-circular-dep-paquerstring.bugfix
+++ b/news/fix-circular-dep-paquerstring.bugfix
@@ -1,0 +1,4 @@
+Fix a circular dependency to `plone.app.querystring`.
+Move `.catalog.CatalogVocabularyFactory` to `plone.app.querystring.vocabularies`, move the ZCML to register the factory, move the the test and put BBB code with deprecation wanring into place.
+Move `.utils.parse_query` with new name `parseAndModifyFormquery` to `plone.app.querystring.queryparser` and put BBB code with deprecation wanring into place.
+[@jensens]

--- a/plone/app/vocabularies/catalog.py
+++ b/plone/app/vocabularies/catalog.py
@@ -331,7 +331,7 @@ class QuerySearchableTextSourceView:
 
     Titles need to be unicode:
     >>> view.getTerm(list(view.results('t'))[0]).title
-    u'/foo'
+    '/foo'
     """
 
     template = ViewPageTemplateFile("searchabletextsource.pt")
@@ -703,7 +703,7 @@ class StaticCatalogVocabulary(CatalogVocabulary):
       <zope.schema.vocabulary.SimpleVocabulary object at ...>
 
       >>> [(t.title, t.value) for t in vocab.search('foo')]
-      [(u'BrainTitle (/1234)', '/1234'), (u'BrainTitle (/2345)', '/2345')]
+      [('BrainTitle (/1234)', '/1234'), ('BrainTitle (/2345)', '/2345')]
 
     We strip out the site path from the rendered path in the title template:
 
@@ -711,21 +711,21 @@ class StaticCatalogVocabulary(CatalogVocabulary):
       >>> context.portal_catalog = catalog
       >>> vocab = StaticCatalogVocabulary({'portal_type': ['Document']})
       >>> [(t.title, t.value) for t in vocab.search('bar')]
-      [(u'BrainTitle (/site/1234)', '/site/1234'),
-       (u'BrainTitle (/site/2345)', '/site/2345')]
+      [('BrainTitle (/site/1234)', '/site/1234'),
+       ('BrainTitle (/site/2345)', '/site/2345')]
 
       >>> context.__name__ = 'site'
       >>> vocab = StaticCatalogVocabulary({'portal_type': ['Document']})
       >>> [(t.title, t.value) for t in vocab.search('bar')]
-      [(u'BrainTitle (/1234)', '/site/1234'),
-       (u'BrainTitle (/2345)', '/site/2345')]
+      [('BrainTitle (/1234)', '/site/1234'),
+       ('BrainTitle (/2345)', '/site/2345')]
 
     The title template can be customized:
 
       >>> vocab.title_template = "{url} {brain.UID} - {brain.Title} {path}"
       >>> [(t.title, t.value) for t in vocab.search('bar')]
-      [(u'proto:/site/1234 /site/1234 - BrainTitle /1234', '/site/1234'),
-       (u'proto:/site/2345 /site/2345 - BrainTitle /2345', '/site/2345')]
+      [('proto:/site/1234 /site/1234 - BrainTitle /1234', '/site/1234'),
+       ('proto:/site/2345 /site/2345 - BrainTitle /2345', '/site/2345')]
 
     """
 

--- a/plone/app/vocabularies/configure.zcml
+++ b/plone/app/vocabularies/configure.zcml
@@ -102,11 +102,6 @@
       />
 
   <utility
-      factory=".catalog.CatalogVocabularyFactory"
-      name="plone.app.vocabularies.Catalog"
-      />
-
-  <utility
       name="plone.app.vocabularies.Actions"
       component=".actions.ActionCategoriesVocabularyFactory"
       />

--- a/plone/app/vocabularies/utils.py
+++ b/plone/app/vocabularies/utils.py
@@ -1,20 +1,7 @@
-from plone.app.querystring import queryparser
-from plone.app.querystring.interfaces import IParsedQueryIndexModifier
-from zope.component import getUtilitiesFor
+from zope.deferredimport import deprecated
 
 
-def parseQueryString(context, query):
-    parsedquery = queryparser.parseFormquery(context, query)
-
-    index_modifiers = getUtilitiesFor(IParsedQueryIndexModifier)
-    for name, modifier in index_modifiers:
-        if name in parsedquery:
-            new_name, query = modifier(parsedquery[name])
-            parsedquery[name] = query
-            # if a new index name has been returned, we need to replace
-            # the native ones
-            if name != new_name:
-                del parsedquery[name]
-                parsedquery[new_name] = query
-
-    return parsedquery
+deprecated(
+    "Import parseQueryString as parseAndModifyFormquery from plone.app.querystring.queryparser instead (will be removed in Plone 7)",
+    parseQueryString="plone.app.querystring.queryparser:parseAndModifyFormquery",
+)

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,11 @@ setup(
     zip_safe=False,
     python_requires=">=3.8",
     install_requires=[
+        # be very careful adding dependencies here, as this package is used
+        # by many many other packages in plone.app.* namespace
+        # it is very easy to add transitive circular dependencies
         "BTrees",
         "Products.ZCatalog",
-        "plone.app.querystring",
         "plone.base",
         "plone.memoize",
         "plone.namedfile",


### PR DESCRIPTION
Move `.catalog.CatalogVocabularyFactory` to `plone.app.querystring.vocabularies`, move the ZCML to register the factory, move the the test and put BBB code with deprecation wanring into place.

Move `.utils.parse_query` with new name `parseAndModifyFormquery` to `plone.app.querystring.queryparser` and put BBB code with deprecation wanring into place.


Has to be tested and merged together with https://github.com/plone/plone.app.querystring/pull/124
GHA test will fail.
