### PR TITLE
Translate column-heading title in listing_tabular

### DIFF
--- a/news/82.bugfix
+++ b/news/82.bugfix
@@ -1,0 +1,2 @@
+Fix the untranslated table-column-heading "Title" in listing_tabular for collections and folders.
+[pbauer]

--- a/plone/app/vocabularies/metadatafields.py
+++ b/plone/app/vocabularies/metadatafields.py
@@ -26,6 +26,7 @@ _FIELD_LABEL = {
     "Type": _("Type"),
     "total_comments": _("Total comments"),
     "mime_type": _("MIME type"),
+    "Title": _("Title"),
 }
 
 


### PR DESCRIPTION
Fix the untranslated table-column-heading "Title" in listing_tabular for collections and folders.