### PR TITLE
Fix token lookup in `ReallyUserFriendlyTypes`

### DIFF
--- a/plone/app/vocabularies/__init__.py
+++ b/plone/app/vocabularies/__init__.py
@@ -1,6 +1,6 @@
 from plone.app.vocabularies.interfaces import IPermissiveVocabulary
 from plone.app.vocabularies.interfaces import ISlicableVocabulary
-from urllib import parse
+from urllib.parse import unquote
 from zope.interface import directlyProvides
 from zope.interface import implementer
 from zope.schema.vocabulary import SimpleTerm
@@ -57,5 +57,5 @@ class PermissiveVocabulary(SimpleVocabulary):
             v = super().getTermByToken(token)
         except LookupError:
             # fallback using dummy term, assumes token==value
-            return SimpleTerm(token, title=parse(token))
+            return SimpleTerm(token, title=unquote(token))
         return v

--- a/plone/app/vocabularies/types.py
+++ b/plone/app/vocabularies/types.py
@@ -280,11 +280,13 @@ class ReallyUserFriendlyTypesVocabulary:
     Containment is unenforced, to make GenericSetup import validation
     handle validation triggered by Choice.fromUnicode() on insertion:
 
-        >>> assert 'arbitrary_value' in util(context)
+        >>> non_friendly_type = types.getTermByToken('Plone Site')
+        >>> non_friendly_type.title, non_friendly_type.token
+        ('Plone Site', 'Plone Site')
 
         >>> doc = types.by_token['Document']
         >>> doc.title, doc.token, doc.value
-        (u'Page', 'Document', 'Document')
+        ('Page', 'Document', 'Document')
     """
 
     def __call__(self, context):


### PR DESCRIPTION
Fix rare case when a "non friendly" type is looked up in `plone.app.vocabularies.ReallyUserFriendlyTypes`
This came up in `collective.collectionfilter` when `Plone Site` type is in filteritems.
The code here was basically a false `urllib.parse` migration to python3