### PR TITLE
Now in CatalogVocabulary getTerms raises LookupError when it cannot f…

### DIFF
--- a/news/106.bugfix
+++ b/news/106.bugfix
@@ -1,0 +1,1 @@
+Now in CatalogVocabulary getTerms raises LookupError when it cannot find the referred object instead of returning None. @parruc

--- a/news/106.bugfix
+++ b/news/106.bugfix
@@ -1,1 +1,1 @@
-Now in CatalogVocabulary getTerms raises LookupError when it cannot find the referred object instead of returning None. @parruc
+Now in CatalogVocabulary getTerm raises LookupError when it cannot find the referred object instead of returning None. @parruc

--- a/plone/app/vocabularies/catalog.py
+++ b/plone/app/vocabularies/catalog.py
@@ -601,6 +601,7 @@ class CatalogVocabulary(SlicableVocabulary):
         brains = self.catalog(**query)
         for b in brains:
             return self.createTerm(b, None)
+        raise LookupError(value)
 
     getTermByToken = getTerm
 


### PR DESCRIPTION
Now in CatalogVocabulary getTerms raises LookupError when it cannot fnd the referred object instead of returning None. 

Closes #106

